### PR TITLE
Remove usernames and manual RTs

### DIFF
--- a/lib/ebooks/generator.rb
+++ b/lib/ebooks/generator.rb
@@ -20,7 +20,11 @@ module Ebooks
       File.open(@corpus_path, 'w') do |file|
         csv_text.reverse_each do |row|
           # Strip links, new lines and usernames
-          tweet_text = row[5].gsub(/(?:f|ht)tps?:\/[^\s]+/, '').gsub(/\n/,' ').gsub(/@[a-z0-9_]+/, '')
+          tweet_text = row[5]
+                        .gsub(/(?:f|ht)tps?:\/[^\s]+/, '')
+                        .gsub(/\n/,' ')
+                        .gsub(/@[a-z0-9_]+/, '')
+                        .gsub(/[R|M]T/, '')
           # Save the text
           file.write("#{tweet_text}\n")
         end

--- a/lib/ebooks/generator.rb
+++ b/lib/ebooks/generator.rb
@@ -19,8 +19,8 @@ module Ebooks
       # Create a new clean file of text that acts as the seed for your Markov chains
       File.open(@corpus_path, 'w') do |file|
         csv_text.reverse_each do |row|
-          # Strip links and new lines
-          tweet_text = row[5].gsub(/(?:f|ht)tps?:\/[^\s]+/, '').gsub(/\n/,' ')
+          # Strip links, new lines and usernames
+          tweet_text = row[5].gsub(/(?:f|ht)tps?:\/[^\s]+/, '').gsub(/\n/,' ').gsub(/@[a-z0-9_]+/, '')
           # Save the text
           file.write("#{tweet_text}\n")
         end

--- a/lib/ebooks/generator.rb
+++ b/lib/ebooks/generator.rb
@@ -19,12 +19,11 @@ module Ebooks
       # Create a new clean file of text that acts as the seed for your Markov chains
       File.open(@corpus_path, 'w') do |file|
         csv_text.reverse_each do |row|
-          # Strip links, new lines, usernames and manual RTs
           tweet_text = row[5]
-                        .gsub(/(?:f|ht)tps?:\/[^\s]+/, '')
-                        .gsub(/\n/,' ')
-                        .gsub(/@[a-z0-9_]+/i, '')
-                        .gsub(/[R|M]T/, '')
+                        .gsub(/(?:f|ht)tps?:\/[^\s]+/, '') # Strip links
+                        .gsub(/\n/,' ') # Strip new lines
+                        .gsub(/@[a-z0-9_]+/i, '') # Strip usernames
+                        .gsub(/[R|M]T/, '') # Strip RTs
           # Save the text
           file.write("#{tweet_text}\n")
         end

--- a/lib/ebooks/generator.rb
+++ b/lib/ebooks/generator.rb
@@ -23,7 +23,7 @@ module Ebooks
           tweet_text = row[5]
                         .gsub(/(?:f|ht)tps?:\/[^\s]+/, '')
                         .gsub(/\n/,' ')
-                        .gsub(/@[a-z0-9_]+/, '')
+                        .gsub(/@[a-z0-9_]+/i, '')
                         .gsub(/[R|M]T/, '')
           # Save the text
           file.write("#{tweet_text}\n")

--- a/lib/ebooks/generator.rb
+++ b/lib/ebooks/generator.rb
@@ -19,7 +19,7 @@ module Ebooks
       # Create a new clean file of text that acts as the seed for your Markov chains
       File.open(@corpus_path, 'w') do |file|
         csv_text.reverse_each do |row|
-          # Strip links, new lines and usernames
+          # Strip links, new lines, usernames and manual RTs
           tweet_text = row[5]
                         .gsub(/(?:f|ht)tps?:\/[^\s]+/, '')
                         .gsub(/\n/,' ')


### PR DESCRIPTION
I've been using this gem for a few weeks, and I figured that removing the usernames and manual RTs might make for more pleasing nonsense :horse_racing: 